### PR TITLE
Add support for textual v6.0.0

### DIFF
--- a/src/textual_tags/__init__.py
+++ b/src/textual_tags/__init__.py
@@ -178,7 +178,10 @@ class Tag(Label):
 
     @property
     def value(self):
-        return self.renderable
+        try:
+            return self.renderable
+        except AttributeError:
+            return self.content
 
 
 class Tags(FlexBoxContainer):


### PR DESCRIPTION
Hi,

Thanks for such a great library 🙌 

In the new major textual version, there are breaking changes, and one of them is not compatible with `textual-tags`.

[v6.0.0 Release notes](https://github.com/Textualize/textual/releases/tag/v6.0.0):
* Breaking change: The renderable property on the Static widget has been changed to content. [#6041](https://github.com/Textualize/textual/pull/6041)

This PR will add support for both pre-v6 and v6 textual versions.

Let me know if you want only to support the latest version of textual, so I will remote try/except.